### PR TITLE
update elm-intdict for use with Elm 0.17

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.2",
+    "version": "1.5.0",
     "summary": "Optimized dictionary specialization for Integers. Mirrors the dictionary API.",
     "repository": "https://github.com/sgraf812/elm-intdict.git",
     "license": "MIT",
@@ -11,7 +11,7 @@
         "IntDict.Safe"
     ],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "4.0.1 <= v < 5.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/IntDict.elm
+++ b/src/IntDict.elm
@@ -1,4 +1,4 @@
-module IntDict
+module IntDict exposing
     ( IntDict
     , isValidKey
     , empty, singleton, insert, update, remove
@@ -7,7 +7,7 @@ module IntDict
     , uniteWith, union, intersect, diff
     , keys, values, toList, fromList
     , toString'
-    ) where
+    )
 
 
 {-| # IntDict

--- a/src/IntDict/Safe.elm
+++ b/src/IntDict/Safe.elm
@@ -1,9 +1,9 @@
-module IntDict.Safe
+module IntDict.Safe exposing
     ( InvalidKey (..)
     , SafeKeyResult
     , safeInsert, safeRemove, safeUpdate
     , safeMember, safeGet
-    ) where
+    )
 
 
 {-| Safe API wrappers for `IntDict`s build and query operators 

--- a/tests/ConsoleRunner.elm
+++ b/tests/ConsoleRunner.elm
@@ -1,12 +1,9 @@
-module Main where
+module Main exposing (..)
 
-import Task exposing (..)
-
-import ElmTest exposing (..)
-import Console
+import Platform exposing (Program)
+import ElmTest exposing (runSuite)
 
 import Test
 
-port runner : Signal (Task x ())
-port runner =
-  Console.run (consoleRunner Test.tests)
+main : Program Never
+main = runSuite Test.tests

--- a/tests/HtmlRunner.elm
+++ b/tests/HtmlRunner.elm
@@ -1,10 +1,9 @@
-module Main where
+module Main exposing (..)
 
-import Graphics.Element exposing (Element, leftAligned)
-import ElmTest exposing (stringRunner)
-import Text exposing (fromString)
+import Platform exposing (Program)
+import ElmTest exposing (runSuiteHtml)
 import Test
 
-main : Element
+main : Program Never
 main =
-  leftAligned (fromString (stringRunner Test.tests))
+  runSuiteHtml Test.tests

--- a/tests/Test.elm
+++ b/tests/Test.elm
@@ -1,4 +1,4 @@
-module Test (tests) where
+module Test exposing (tests)
 
 
 import Test.IntDict

--- a/tests/Test/IntDict.elm
+++ b/tests/Test/IntDict.elm
@@ -1,4 +1,4 @@
-module Test.IntDict (tests) where
+module Test.IntDict exposing (tests)
 
 {-| Copied and modified from `Dict`s test suite. -}
 

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "summary": "Test suite for IntDict",
     "repository": "https://github.com/sgraf812/elm-intdict.git",
     "license": "MIT",
@@ -9,9 +9,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "deadfoxygrandpa/elm-test": "3.0.1 <= v < 4.0.0",
-        "elm-lang/core": "3.0.0 <= v < 4.0.0",
-        "laszlopandy/elm-console": "1.0.3 <= v < 1.0.4"
+        "elm-community/elm-test": "1.1.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.1 <= v < 5.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
# Summary of changes
- Bumps the minor versions of elm-intdict and tests
- Changes the elm-package.json files to use Elm 0.17
- Changes the tests to use elm-community/elm-test
# Explanation

I wanted to use [your elm-graph library](https://github.com/sgraf812/elm-graph) with elm-0.17, and this is one of the dependencies. Aside from a little rewiring in the `tests` directory, the only changes are module-related syntax changes (where elm previously used `module X (y, z) where`, it now uses `module X exposing (y, z)`).

Let me know if there are problems with it — I wasn’t sure that bumping the minor version was the right choice here.
